### PR TITLE
[LB-115] Extract GS Terms from Execution.json

### DIFF
--- a/backend/services/extract_gui_data.py
+++ b/backend/services/extract_gui_data.py
@@ -57,11 +57,16 @@ def extract_gs_terms(json_path: str):
     # For each step extract step.screen.activity and/or step.screen.window value
     for step in last_4_steps:
         activity = step.get("screen", {}).get("activity", "")
+        window = step.get("screen", {}).get("window", "")
 
         # Use Regex to match Activity name before (Window.*)
-        # Note: Highly dependent on Trace Replayer data format. If it changes this line will have to change 
         gs_activity = re.search(r'(\w+)(\(Window.*\))', activity)
         if gs_activity:
             gs_terms.add(gs_activity.group(1))
+
+        # Use Regex to match windows only if the FRAGMENT tag is present
+        gs_window = re.search(r'FRAGMENT:(.+)', window)
+        if gs_window:
+            gs_terms.add(gs_window.group(1))
 
     return list(gs_terms)

--- a/backend/temp_testing/Execution-1.json
+++ b/backend/temp_testing/Execution-1.json
@@ -95544,7 +95544,7 @@
         "screen":
         {
             "activity": "io.github.zwieback.familyfinance.business.template.activity.TemplateActivity(Window\u003dMain)",
-            "window": "ACTIVITY:io.github.zwieback.familyfinance.debugio.github.zwieback.familyfinance.business.template.activity.TemplateActivity",
+            "window": "FRAGMENT:AddFeedFragment",
             "dynGuiComponents": [
             {
                 "activity": "io.github.zwieback.familyfinance.debugio.github.zwieback.familyfinance.business.template.activity.TemplateActivity",
@@ -96065,7 +96065,7 @@
         "screen":
         {
             "activity": "io.github.zwieback.familyfinance.business.dashboard.activity.DashboardActivity(Window\u003dMain)",
-            "window": "ACTIVITY:io.github.zwieback.familyfinance.debugio.github.zwieback.familyfinance.business.dashboard.activity.DashboardActivity",
+            "window": "FRAGMENT:SubscriptionFragment",
             "dynGuiComponents": [
             {
                 "activity": "io.github.zwieback.familyfinance.debugio.github.zwieback.familyfinance.business.dashboard.activity.DashboardActivity",

--- a/backend/tests/test_extract_gui_data.py
+++ b/backend/tests/test_extract_gui_data.py
@@ -1,7 +1,8 @@
 from services.extract_gui_data import extract_sc_terms
+from services.extract_gui_data import extract_gs_terms
 
 def test_extract_SC_terms():
-    json_path = "temp_testing/Execution-1.json" # Replace with the actual path to your test file
+    json_path = "backend/temp_testing/Execution-1.json" # Replace with the actual path to your test file
 
     expected_sc_terms = [
         "action_bar_root",
@@ -34,3 +35,12 @@ def test_extract_SC_terms():
     extracted_terms = sorted(extract_sc_terms(json_path))
 
     assert extracted_terms == expected_sc_terms, f"Mismatch: {extracted_terms}"
+
+def test_extract_GS_terms():
+    json_path = "backend/temp_testing/Execution-1.json"
+
+    expected_gs_terms = []
+
+    extracted_terms = extract_gs_terms(json_path)
+
+    assert extracted_terms == expected_gs_terms, f"Mismatch: {extracted_terms}"

--- a/backend/tests/test_extract_gui_data.py
+++ b/backend/tests/test_extract_gui_data.py
@@ -39,7 +39,10 @@ def test_extract_SC_terms():
 def test_extract_GS_terms():
     json_path = "backend/temp_testing/Execution-1.json"
 
-    expected_gs_terms = []
+    expected_gs_terms = [
+        "DashboardActivity",
+        "TemplateActivity"
+    ]
 
     extracted_terms = extract_gs_terms(json_path)
 

--- a/backend/tests/test_extract_gui_data.py
+++ b/backend/tests/test_extract_gui_data.py
@@ -2,7 +2,7 @@ from services.extract_gui_data import extract_sc_terms
 from services.extract_gui_data import extract_gs_terms
 
 def test_extract_SC_terms():
-    json_path = "backend/temp_testing/Execution-1.json" # Replace with the actual path to your test file
+    json_path = "temp_testing/Execution-1.json"
 
     expected_sc_terms = [
         "action_bar_root",
@@ -37,13 +37,15 @@ def test_extract_SC_terms():
     assert extracted_terms == expected_sc_terms, f"Mismatch: {extracted_terms}"
 
 def test_extract_GS_terms():
-    json_path = "backend/temp_testing/Execution-1.json"
+    json_path = "temp_testing/Execution-1.json"
 
     expected_gs_terms = [
-        "DashboardActivity",
-        "TemplateActivity"
+        'AddFeedFragment',
+        'DashboardActivity',
+        'SubscriptionFragment',
+        'TemplateActivity'
     ]
 
-    extracted_terms = extract_gs_terms(json_path)
+    extracted_terms = sorted(extract_gs_terms(json_path))
 
     assert extracted_terms == expected_gs_terms, f"Mismatch: {extracted_terms}"


### PR DESCRIPTION
**Overview**
Add function to extract GUI Screen terms from the Execution.json. Returns a list of GS terms that represent the Activity/Fragment names.

**Changes Made**
extract_gui_data.py: Added extract_gs_terms to handle Screen term extraction
Execution-1.json: Added test cases for Fragments
test_extract_gui_data.py: Added unit test for GS extraction

**Testing**
Manually set up test cases in Execution-1.json and unit tests in test_extract_gui_data.py