### PR TITLE
[LB-117] Map SC terms to Java files (build corpus)

### DIFF
--- a/backend/services/extract_gui_data.py
+++ b/backend/services/extract_gui_data.py
@@ -1,4 +1,3 @@
-import glob
 import json
 import re
 
@@ -92,21 +91,22 @@ def check_if_term_exist(search_terms, file_content):
 
     return is_matched_keyword
 
-def map_sc_terms_to_files(java_files_data: list[dict], sc_terms: list[str]):
+def build_corpus(source_code_files: list[tuple], sc_terms: list[str]):
     """
     Maps SC terms to files using a brute force approach.
 
     Args: 
-        java_files_data (list[dict]): A list of dictionaries where each dictionary represents a file with its path and contents
+        source_code_files (list[tuple]): A list of source code file tuples that contain (file_path, file_name, file_content)
 
     Returns: 
         sc_files (list[str]): A list of strings with each string being the file path of a mapped SC file
     """
     sc_files = []
-    for file_data in java_files_data:
-        search_term_exist = check_if_term_exist(sc_terms, file_data["contents"])
+
+    for file in source_code_files:
+        search_term_exist = check_if_term_exist(sc_terms, file[2])
 
         if search_term_exist == True:
-            sc_files.append(file_data["path"])
+            sc_files.append(file[0])
 
     return sc_files

--- a/backend/services/extract_gui_data.py
+++ b/backend/services/extract_gui_data.py
@@ -103,7 +103,7 @@ def build_corpus(source_code_files: list[tuple], sc_terms: list[str]):
     sc_files = []
 
     for file in source_code_files:
-        search_term_exist = check_if_term_exist(sc_terms, file[2])
+        search_term_exist = check_if_sc_term_exists(sc_terms, file[2])
 
         if search_term_exist == True:
             sc_files.append(file[0])

--- a/backend/services/extract_gui_data.py
+++ b/backend/services/extract_gui_data.py
@@ -71,10 +71,9 @@ def extract_gs_terms(json_path: str):
 
     return list(gs_terms)
 
-def check_if_term_exist(search_terms, file_content):
+def check_if_sc_term_exists(search_terms, file_content):
     """
-    Checks if any search terms (SC or GS terms) exist in the contents of a file. This function does NOT map
-    any search terms to file paths.
+    Checks if any SC terms exist in the contents of a file.
     Credit: Junayed Mahmud
 
     Args:

--- a/backend/services/extract_gui_data.py
+++ b/backend/services/extract_gui_data.py
@@ -1,3 +1,4 @@
+import glob
 import json
 import re
 
@@ -70,3 +71,36 @@ def extract_gs_terms(json_path: str):
             gs_terms.add(gs_window.group(1))
 
     return list(gs_terms)
+
+def get_file_content(self, file_name):
+		# Read the file
+		file_content = open(file_name, "r")
+		file_content = file_content.read()
+		return file_content
+
+def check_if_term_exist(self, search_terms, file_content):
+		is_matched_keyword = False
+		for keyword in search_terms:
+			if keyword in file_content:
+				match_keyword = True
+
+		return is_matched_keyword
+
+def map_sc_terms_to_files(java_files_data: list[dict], sc_terms: list[str]):
+    """
+    Maps SC terms to files using a brute force approach.
+
+    Args: 
+        java_files_data (list[dict]): A list of dictionaries where each dictionary represents a file with its path and contents
+
+    Returns: 
+        sc_files (list[str]): A list of strings with each string being the file path of a mapped SC file
+    """
+    sc_files = []
+    for file_data in java_files_data:
+        search_term_exist = check_if_term_exist(sc_terms, file_data["contents"])
+
+        if search_term_exist == True:
+            sc_files.append(file_data["path"])
+
+    return sc_files

--- a/backend/services/extract_gui_data.py
+++ b/backend/services/extract_gui_data.py
@@ -72,19 +72,25 @@ def extract_gs_terms(json_path: str):
 
     return list(gs_terms)
 
-def get_file_content(self, file_name):
-		# Read the file
-		file_content = open(file_name, "r")
-		file_content = file_content.read()
-		return file_content
+def check_if_term_exist(search_terms, file_content):
+    """
+    Checks if any search terms (SC or GS terms) exist in the contents of a file. This function does NOT map
+    any search terms to file paths.
+    Credit: Junayed Mahmud
 
-def check_if_term_exist(self, search_terms, file_content):
-		is_matched_keyword = False
-		for keyword in search_terms:
-			if keyword in file_content:
-				match_keyword = True
+    Args:
+        search_terms (list[str]): A list of strings representing either SC or GS terms
+        file_content (str): The contents of a Java file
 
-		return is_matched_keyword
+    Returns:
+        is_matched_keyword (bool): True if a search term was found in the file contents, otherwise false.
+    """    
+    is_matched_keyword = False
+    for keyword in search_terms:
+        if keyword in file_content:
+            is_matched_keyword = True
+
+    return is_matched_keyword
 
 def map_sc_terms_to_files(java_files_data: list[dict], sc_terms: list[str]):
     """

--- a/backend/tests/test_extract_gui_data.py
+++ b/backend/tests/test_extract_gui_data.py
@@ -1,5 +1,6 @@
 from services.extract_gui_data import extract_sc_terms
 from services.extract_gui_data import extract_gs_terms
+from services.extract_gui_data import build_corpus
 
 def test_extract_SC_terms():
     json_path = "temp_testing/Execution-1.json"
@@ -49,3 +50,29 @@ def test_extract_GS_terms():
     extracted_terms = sorted(extract_gs_terms(json_path))
 
     assert extracted_terms == expected_gs_terms, f"Mismatch: {extracted_terms}"
+
+def test_build_corpus():
+    sc_terms = [
+        'add_expense',
+        'content',
+        'select_account',
+        'toolbar'
+    ]
+
+    source_code_files = [
+        ('path/to/Expenses.java', 'Expenses.java', 'public static void main(String[] args) { int add_expense = 5;}'),
+        ('path/to/file1', 'file1', 'mock code'),
+        ('path/to/file2', 'file1', 'mock code'),
+        ('path/to/ToolbarScreen.java', 'ToolbarScreen.java', 'public static void main(String[] args) { int toolbar = 5;}'),
+        ('path/to/file3', 'file1', 'mock code'),
+        ('path/to/file1', 'file1', 'mock code'),
+    ]
+
+    expected_corpus_files = [
+        'path/to/Expenses.java',
+        'path/to/ToolbarScreen.java'
+    ]
+
+    corpus_files = build_corpus(source_code_files, sc_terms)
+
+    assert corpus_files == expected_corpus_files, f"Mismatch: {corpus_files}"

--- a/backend/tests/test_extract_gui_data.py
+++ b/backend/tests/test_extract_gui_data.py
@@ -65,6 +65,18 @@ def test_build_corpus():
         ('path/to/file1', 'file1', 'mock code'),
         ('path/to/file2', 'file1', 'mock code'),
         ('path/to/ToolbarScreen.java', 'ToolbarScreen.java', 'public static void main(String[] args) { int toolbar = 5;}'),
+        ('path/to/file3', 'file1', 'mock code'),
+        ('path/to/file1', 'file1', 'mock code'),
+    ]
+
+    expected_corpus_files = [
+        'path/to/Expenses.java',
+        'path/to/ToolbarScreen.java'
+    ]
+
+    corpus_files = build_corpus(source_code_files, sc_terms)
+
+    assert corpus_files == expected_corpus_files, f"Mismatch: {corpus_files}"
 
 def test_get_boosted_files():
     gs_terms = [
@@ -82,15 +94,6 @@ def test_get_boosted_files():
         ('path/to/file3', 'file1', 'mock code'),
         ('path/to/file1', 'file1', 'mock code'),
     ]
-
-    expected_corpus_files = [
-        'path/to/Expenses.java',
-        'path/to/ToolbarScreen.java'
-    ]
-
-    corpus_files = build_corpus(source_code_files, sc_terms)
-
-    assert corpus_files == expected_corpus_files, f"Mismatch: {corpus_files}"
 
     expected_boosted_files = [
         'path/to/AddFeedFragment.java',


### PR DESCRIPTION
**Overview**
This PR adds functionality to map SC terms to Java files. This PR does not add functionality to pull Java file contents from the database.

**Changes Made**
* Added `map_sc_terms_to_files()` function
* Added `check_if_terms_exist()` function (thanks big Juna)

**Testing Strategy**
* Additional test case added to `test_extract_gui_data.py`