### PR TITLE
[LB-120] Retrieve Source Code Files from DB

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -189,6 +189,23 @@ def report():
             send_update_to_probot(repo_info['owner'], repo_info['repo_name'], comment_id,
                                   f"❌ **Embeddings Update Failed**: {e}")
             abort(500, description=str(e))
+    # Fetch all source code files from DB
+    try:
+        query = {
+            "repo_name": repo_info['repo_name'],
+            "owner": repo_info['owner']
+        }
+        # Get the repo document for the query     
+        repo_collection = db.get_repo_collection()
+        query_repo = repo_collection.find_one(query)
+        repo_files = db.get_repo_file_contents(query_repo["_id"])
+        send_update_to_probot(repo_info['owner'], repo_info['repo_name'], comment_id,
+                              "📚 **Source Code Files Fetched**: Retrieved all source code files from the database.")
+    except Exception as e:
+        logger.info('Failed to find repo.')
+        send_update_to_probot(repo_info['owner'], repo_info['repo_name'], comment_id,
+                              "❌ **Source Code Retrieval Failed**: Could not fetch source code from the database.")
+        return jsonify({"message": "Failed to find repo."}), 405
 
     # FETCH ALL EMBEDDINGS FROM DB
     try:

--- a/backend/database/database.py
+++ b/backend/database/database.py
@@ -21,7 +21,7 @@ class Database:
             cls._instance.__client = None
         return cls._instance
     
-    def __init__(self, database='test', repo_collection='repos', embeddings_collection='embeddings'):
+    def __init__(self, database='test', repo_collection='repos', embeddings_collection='embeddings', files_collection='files'):
         # Set up basic logging
         logging.basicConfig(level=logging.INFO)
         self.logger = logging.getLogger(__name__)
@@ -35,6 +35,7 @@ class Database:
         self.__database = self.__client[database]
         self.__repos = self.__database[repo_collection]
         self.__embeddings = self.__database[embeddings_collection]
+        self.__files = self.__database[files_collection]
 
     def __initialize_database_client(self, password):
         if self.__client is not None:
@@ -84,6 +85,27 @@ class Database:
             embeddings.append((document.get("route"), document.get("embedding")))
 
         return embeddings
+    
+    def get_repo_file_contents(self, repo_id):
+        """
+        Gets all source code file contents from a specific repository in the 'files' collection
+
+        Args: 
+            repo_id of desired repository
+
+        Returns:
+            A list of tuples with the (file_path, file_name, file_contents)
+        """
+
+        files = []
+        results = self.__files.find({"repo_id": repo_id})
+
+        for document in results:
+            file_path = document.get("route")
+            file_name = os.path.basename(file_path)
+            files.append((file_path, file_name, document.get("code content")))
+
+        return files
     
     def insert_embeddings_document(self, embeddings_document, **kwargs):
         self.logger.debug("Storing embeddings in database.")


### PR DESCRIPTION
Added/modified methods to retrieve relevant source code files from the 'files' collection in the database.

**Changes**
- database.py: Added `get_repo_file_contents(self, repo_id)` to return of tuple of source code data that will be used for filtering/boosting and corpus building. Tuple format: `(file_path, file_name, file_contents)`
- routes.py: Added try-catch to get source code file data and send update to probot 

Live tested the endpoint on a test repo