### PR TITLE
[LB-118] Map GS terms to Source Code Files for Boosting

### DIFF
--- a/backend/services/extract_gui_data.py
+++ b/backend/services/extract_gui_data.py
@@ -70,3 +70,24 @@ def extract_gs_terms(json_path: str):
             gs_terms.add(gs_window.group(1))
 
     return list(gs_terms)
+
+def get_boosted_files(source_code_files: list[tuple], gs_terms: list[str]):
+    """
+    Maps GS terms to files via matching file names
+
+    Args:
+        source_code_files (list[tuple]): A list of source code file tuples that contain (file_path, file_name, file_content)
+        gs_terms (list[str]): A list of screen names from execution data
+
+    Returns:
+        gs_files: List of file paths of matching gs_files that will be boosted 
+    """
+    gs_files = []
+
+    # Go through each source code file
+    for file in source_code_files:
+        # Check if the file name matches any of the GS terms and add the file path
+        if any(gs_term in file[1] for gs_term in gs_terms):
+            gs_files.append(file[0])
+
+    return gs_files

--- a/backend/tests/test_extract_gui_data.py
+++ b/backend/tests/test_extract_gui_data.py
@@ -1,5 +1,6 @@
 from services.extract_gui_data import extract_sc_terms
 from services.extract_gui_data import extract_gs_terms
+from services.extract_gui_data import get_boosted_files
 
 def test_extract_SC_terms():
     json_path = "temp_testing/Execution-1.json"
@@ -49,3 +50,29 @@ def test_extract_GS_terms():
     extracted_terms = sorted(extract_gs_terms(json_path))
 
     assert extracted_terms == expected_gs_terms, f"Mismatch: {extracted_terms}"
+
+def test_get_boosted_files():
+    gs_terms = [
+        'AddFeedFragment',
+        'DashboardActivity',
+        'SubscriptionFragment',
+        'TemplateActivity'
+    ]
+
+    source_code_files = [
+        ('path/to/AddFeedFragment', 'AddFeedFragment', 'mock code'),
+        ('path/to/file1', 'file1', 'mock code'),
+        ('path/to/file2', 'file1', 'mock code'),
+        ('path/to/DashboardActivity', 'DashboardActivity', 'mock code'),
+        ('path/to/file3', 'file1', 'mock code'),
+        ('path/to/file1', 'file1', 'mock code'),
+    ]
+
+    expected_boosted_files = [
+        'path/to/AddFeedFragment',
+        'path/to/DashboardActivity'
+    ]
+
+    boosted_files = get_boosted_files(source_code_files, gs_terms)
+
+    assert boosted_files == expected_boosted_files, f"Mismatch: {boosted_files}"


### PR DESCRIPTION
Created a method that maps GS files to source code file names to be used for boosting.

**Changes**
- extract_gui_data.py: added `get_boosted_files(source_code_files: list[tuple], gs_terms: list[str])` to return a list of file routes that will be boosted
- test_extract_gui_data.py: added tests to assert that matching file names are returned

**Testing strategy**
Unit test assertion
