### PR TITLE
[LB-133] Fix returned rankings

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -248,15 +248,16 @@ def report():
     ranked_files = bug_localizer.rank_files(preprocessed_bug_report, corpus_embeddings)
     reranked_files = reorder_rankings(ranked_files, boosted_files)
 
-    ranked_list = []
+    top_ten_files = []
 
+    # Only return top ten files
     for i in range(min(10, len(reranked_files))):
-        ranked_list.append(reranked_files[i])
+        top_ten_files.append(reranked_files[i])
 
     # Return rankings to GitHub
     send_update_to_probot(repo_info['owner'], repo_info['repo_name'], comment_id,
                           "🎯 **Bug Localization Completed**: Ranked relevant files identified.")
-    return jsonify({"message": "Report processed successfully", "ranked_files": reranked_files}), 200
+    return jsonify({"message": "Report processed successfully", "ranked_files": top_ten_files}), 200
 
 
 # ======================================================================================================================


### PR DESCRIPTION
**Overview**
This PR pushes a fix to a bug where all files in the corpus are returned in the rankings. Intended behavior is that only the top ten files are returned back to GitHub

**Changes to Fix**
* Old code was appending to the wrong list
* Fixed list and updated list name to avoid confusion