### PR TITLE
[LB-134] Fix fetch corpus embeddings

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -221,7 +221,7 @@ def report():
         return jsonify({"message": "Failed to find repo."}), 405
 
     # Apply filtering and get boosted files
-    corpus = build_corpus(repo_files, sc_terms)
+    corpus = build_corpus(repo_files, sc_terms, repo_info)
     boosted_files = get_boosted_files(repo_files, gs_terms)
 
     # FETCH ALL EMBEDDINGS FROM DB

--- a/backend/database/database.py
+++ b/backend/database/database.py
@@ -105,14 +105,13 @@ class Database:
         embeddings = []
         
         # Perform a single query to fetch all matching documents
-        query = {"repo_id": repo_id, "route": {"$in": corpus}}
-        results = self.__embeddings.find(query, {"route": 1, "embedding": 1})
+        results = self.__embeddings.find({"repo_id": repo_id, "route": {"$in": corpus}})
 
-        # Convert results into a dictionary for fast lookup
-        embeddings_dict = {doc["route"]: doc["embedding"] for doc in results}
+        for document in results:
+            embeddings.append((document.get("route"), document.get("embedding")))
 
         # Preserve order and return as tuples
-        return [(route, embeddings_dict.get(route)) for route in corpus]
+        return embeddings
 
     def get_repo_file_contents(self, repo_id):
         """

--- a/backend/services/extract_gui_data.py
+++ b/backend/services/extract_gui_data.py
@@ -1,5 +1,6 @@
 import json
 import re
+import os
 
 def extract_sc_terms(json_string: str):
     """
@@ -88,7 +89,7 @@ def check_if_sc_term_exists(search_terms, file_content):
 
     return is_matched_keyword
 
-def build_corpus(source_code_files: list[tuple], sc_terms: list[str]):
+def build_corpus(source_code_files: list[tuple], sc_terms: list[str], repo_info):
     """
     Maps SC terms to files using a brute force approach.
 
@@ -98,13 +99,15 @@ def build_corpus(source_code_files: list[tuple], sc_terms: list[str]):
     Returns: 
         sc_files (list[str]): A list of strings with each string being the file path of a mapped SC file
     """
+    repo_dir = os.path.join('repos', repo_info['owner'], repo_info['repo_name'])
+
     sc_files = []
 
     for file in source_code_files:
         search_term_exist = check_if_sc_term_exists(sc_terms, file[2])
 
         if search_term_exist == True:
-            sc_files.append(file[0])
+            sc_files.append(file[0].replace(repo_dir + '/', ''))
 
     return sc_files
 

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -39,12 +39,12 @@ def mock_database():
 
 def test_get_corpus_files_embeddings(mock_database):
     repo_id = "12345"
-    corpus = ["path/to/file1.java", "to/file5.java", "to/file5.java"] 
+    corpus = ["path/to/file1.java", "to/file5.java", "file10.java"] 
 
     expected_output = [
         ("path/to/file1.java", [0.1, 0.2, 0.3]),
         ("to/file5.java", [0.7, 0.8, 0.9]),
-        ("to/file5.java", [0.7, 0.8, 0.9]),  
+        ("file10.java", [0.7, 0.8, 0.9]),  
     ]
 
     result = mock_database.get_corpus_files_embeddings(repo_id, corpus)

--- a/backend/tests/test_extract_gui_data.py
+++ b/backend/tests/test_extract_gui_data.py
@@ -54,6 +54,10 @@ def test_extract_GS_terms():
     assert extracted_terms == expected_gs_terms, f"Mismatch: {extracted_terms}"
 
 def test_build_corpus():
+    repo_info = {
+        "repo_name": "some-repo",
+        "owner": "someone"
+    }
     sc_terms = [
         'add_expense',
         'content',
@@ -62,12 +66,12 @@ def test_build_corpus():
     ]
 
     source_code_files = [
-        ('path/to/Expenses.java', 'Expenses.java', 'public static void main(String[] args) { int add_expense = 5;}'),
-        ('path/to/file1', 'file1', 'mock code'),
-        ('path/to/file2', 'file1', 'mock code'),
-        ('path/to/ToolbarScreen.java', 'ToolbarScreen.java', 'public static void main(String[] args) { int toolbar = 5;}'),
-        ('path/to/file3', 'file1', 'mock code'),
-        ('path/to/file1', 'file1', 'mock code'),
+        ('repos/someone/some-repo/path/to/Expenses.java', 'Expenses.java', 'public static void main(String[] args) { int add_expense = 5;}'),
+        ('repos/someone/some-repo/path/to/file1', 'file1', 'mock code'),
+        ('repos/someone/some-repo/path/to/file2', 'file1', 'mock code'),
+        ('repos/someone/some-repo/path/to/ToolbarScreen.java', 'ToolbarScreen.java', 'public static void main(String[] args) { int toolbar = 5;}'),
+        ('repos/someone/some-repo/path/to/file3', 'file1', 'mock code'),
+        ('repos/someone/some-repo/path/to/file1', 'file1', 'mock code'),
     ]
 
     expected_corpus_files = [
@@ -75,7 +79,7 @@ def test_build_corpus():
         'path/to/ToolbarScreen.java'
     ]
 
-    corpus_files = build_corpus(source_code_files, sc_terms)
+    corpus_files = build_corpus(source_code_files, sc_terms, repo_info)
 
     assert corpus_files == expected_corpus_files, f"Mismatch: {corpus_files}"
 


### PR DESCRIPTION
**Overview**
This PR fixes a bug where corpus embeddings were not being returned from the database. The issue was that file paths in the corpus were not cleaned of the `repos/owner/repo_name` prefix before being added to the corpus, leading to the `get_corpus_files_embeddings()` function to return `None`.

**Changes Made**
* Rewrote the `get_corpus_files_embeddings()` function to match the `get_repo_files_embeddings()` function
* Updated `build_corpus()` to clean file paths
* Updated all tests accordingly

**Tests**
* Tested live on GitHub with a deployed probot