### PR TITLE
[LB-149] Separate out calls to GitHub from helper functions

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -353,7 +353,7 @@ def partial_clone(old_sha, repo_info):
     github_diff_data = get_diff_from_github(repo_info, old_sha, new_sha)
     changed_files = create_changed_files_dict(github_diff_data, repo_dir)
 
-    zip_archive = get_zip_archive(repo_info)
+    zip_archive = get_latest_repo_data_from_github(repo_info)
 
     extract_files(changed_files, zip_archive, repo_dir)
 
@@ -413,20 +413,19 @@ def create_changed_files_dict(github_diff_data, repo_dir):
         logger.error("Error: 'files' key not found in response data.")
         return None
 
-def get_zip_archive(repo_info):
+def get_latest_repo_data_from_github(repo_info):
     """
-    Fetches the zipfile of the repository at the latest commit
+    Gets the latest repo data as a zip file.
 
     :param repo_info: Dictionary containing repository info
     :return zip_archive: The zipfile of the repository at the latest commit
     """
-    # Download repo at the latest commit
+
     url = f"https://api.github.com/repos/{repo_info['owner']}/{repo_info['repo_name']}/zipball/{repo_info['latest_commit_sha']}"
     response = requests.get(url)
 
     if response.status_code == 200:
-        zip_archive = zipfile.ZipFile(io.BytesIO(response.content))
-        return zip_archive
+        return zipfile.ZipFile(io.BytesIO(response.content))
     else:
         print("Failed to download zip archive.")
 


### PR DESCRIPTION
**Overview**
This PR separates out GitHub API calls from helper functions to uphold the single responsibility principle of functions. It also makes creating unit tests easier for helper functions.

**Changes Made**
* Created a new function `get_diff_from_github()` that makes a GET request to GitHub to get the diff between two commits
* Renamed `get_changed_files()` to `create_changed_files_dict()` to reserve `get` for functions making GET requests to external dependencies
* Renamed `get_zip_archive()` to `get_latest_repo_data_from_github()` to clearly define function responsibility

**Testing Strategy**
* Live testing on [this issue](https://github.com/LadyBugML/bug-8/issues/18)