### PR TITLE
[LB 144] Create unit tests for helper methods

### DIFF
--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -1,5 +1,71 @@
 from app.api.routes import reorder_rankings
+from app.api.routes import create_changed_files_dict
 
+def test_create_changed_files_dict_with_added_files():
+    github_diff_data = {
+        "files": [
+            {"filename": "src/main/java/com/example/NewFile.java", "status": "added"},
+            {"filename": "src/main/java/com/example/AnotherFile.java", "status": "added"}
+        ]
+    }
+    repo_dir = "repo_owner/repo_name"
+    expected_result = {
+        "added": ["src/main/java/com/example/NewFile.java", "src/main/java/com/example/AnotherFile.java"],
+        "modified": [],
+        "removed": []
+    }
+    result = create_changed_files_dict(github_diff_data, repo_dir)
+    assert result == expected_result, f"Expected {expected_result}, but got {result}"
+
+def test_create_changed_files_dict_with_modified_files():
+    github_diff_data = {
+        "files": [
+            {"filename": "src/main/java/com/example/ModifiedFile.java", "status": "modified"},
+            {"filename": "src/main/java/com/example/AnotherModifiedFile.java", "status": "modified"}
+        ]
+    }
+    repo_dir = "repo_dir"
+    expected_result = {
+        "added": [],
+        "modified": ["src/main/java/com/example/ModifiedFile.java", "src/main/java/com/example/AnotherModifiedFile.java"],
+        "removed": []
+    }
+    result = create_changed_files_dict(github_diff_data, repo_dir)
+    assert result == expected_result, f"Expected {expected_result}, but got {result}"
+
+def test_create_changed_files_dict_with_removed_files():
+    github_diff_data = {
+        "files": [
+            {"filename": "src/main/java/com/example/RemovedFile.java", "status": "removed"},
+            {"filename": "src/main/java/com/example/AnotherRemovedFile.java", "status": "removed"}
+        ]
+    }
+    repo_dir = "repo_dir"
+    expected_result = {
+        "added": [],
+        "modified": [],
+        "removed": ["src/main/java/com/example/RemovedFile.java", "src/main/java/com/example/AnotherRemovedFile.java"]
+    }
+    result = create_changed_files_dict(github_diff_data, repo_dir)
+    assert result == expected_result, f"Expected {expected_result}, but got {result}"
+
+def test_create_changed_files_dicf_with_all_types_of_files():
+    github_diff_data = {
+        "files": [
+            {"filename": "src/main/java/com/example/NewFile.java", "status": "added"},
+            {"filename": "src/main/java/com/example/ModifiedFile.java", "status": "modified"},
+            {"filename": "src/main/java/com/example/RemovedFile.java", "status": "removed"}
+        ]
+    }
+    repo_dir = "repo_dir"
+    expected_result = {
+        "added": ["src/main/java/com/example/NewFile.java"],
+        "modified": ["src/main/java/com/example/ModifiedFile.java"],
+        "removed": ["src/main/java/com/example/RemovedFile.java"]
+    }
+    result = create_changed_files_dict(github_diff_data, repo_dir)
+    assert result == expected_result, f"Expected {expected_result}, but got {result}"
+    
 def test_reorder_rankings():
     ranked_files = [
         ("path/to/file1.java", 0.59),


### PR DESCRIPTION
**Overview**
This PR creates unit tests for helper methods involved in the `initialization()` and `report()` endpoints. This test suite does not include tests for functions that interact with the database. This is because these functions will most likely be refactored soon and creating tests would be easier after that is complete.

**Tests Created**
- `create_changed_files_dict()`
- `extract_files()`
- `post_process_cleanup()`
- `write_file_for_report_preprocessing()`
- `change_repository_file_permissions()`
- `extract_and_validate_repo_info()`