### PR TITLE
Add method chunking and remove preprocessing

### DIFF
--- a/backend/experimental_unixcoder/bug_localization.py
+++ b/backend/experimental_unixcoder/bug_localization.py
@@ -1,4 +1,6 @@
 import torch
+from tree_sitter import Language, Parser
+import tree_sitter_java as tsjava
 
 try:
     from experimental_unixcoder.unixcoder import UniXcoder  # Try live version
@@ -14,36 +16,106 @@ class BugLocalization:
         self.model = UniXcoder("microsoft/unixcoder-base")
         self.model.to(self.device)
 
-        # Encoding for Long Texts
-    def encode_text(self, text, verbose=False):
+        # Initialize tree-sitter
+        JAVA_LANGUAGE = Language(tsjava.language())
+        self.parser = Parser(JAVA_LANGUAGE)
+
+
+    def encode_code(self, code_str):
         """
-        Encodes long text by splitting it into chunks of roughly 500 characters
-        (before tokenization). Each chunk is tokenized and encoded individually.
-        Returns a list of embeddings (as lists), one for each chunk.
+        Encodes source code into embeddings using the model.
+
+        Args:
+            code_str (str): The source code to encode.
+
+        Returns:
+            list: A list of normalized embeddings for the code chunks.
         """
-        chunk_size = 500  # Split by 500 characters as an example
+
+        chunks = self.extract_methods_from_java(code_str)
         embeddings = []
 
-        # Split text into roughly 500-character chunks
-        for i in range(0, len(text), chunk_size):
-            text_chunk = text[i:i + chunk_size]
-            if verbose:
-                print(f"Processing text chunk {i // chunk_size + 1}")  # Debug print
+        for chunk in chunks:
+            inputs = self.tokenizer(chunk, return_tensors="pt", truncation=True, padding=True, max_length=self.max_tokens).to(self.device)
+            with torch.no_grad():
+                output = self.model(**inputs)[0]  # shape: [1, 256]
+                norm_embedding = torch.nn.functional.normalize(output, p=2, dim=-1)
+                embeddings.append(norm_embedding.squeeze(0).tolist())
 
-            # Tokenize the chunk
-            tokens = self.model.tokenize([text_chunk], mode="<encoder-only>")[0]
-            source_ids = torch.tensor([tokens]).to(self.device)
-            
-            # Get model output
-            try:
-                _, embedding = self.model(source_ids)
-                norm_embedding = torch.nn.functional.normalize(embedding, p=2, dim=1)
-                embeddings.append(norm_embedding.tolist())  # Store normalized embedding as list
-            except Exception as e:
-                print(f"Error processing chunk {i // chunk_size + 1}: {e}")
-                continue
-        # print(embeddings)
         return embeddings
+
+
+    def encode_bug_report(self, text):
+        """
+        Encodes a bug report into an embedding using the model.
+
+        Args:
+            text (str): The bug report text to encode.
+
+        Returns:
+            list: A normalized embedding for the bug report.
+        """
+
+        inputs = self.tokenizer(text, return_tensors="pt", truncation=True, padding=True).to(self.device)
+        with torch.no_grad():
+            output = self.model(**inputs)[0]
+            norm_embedding = torch.nn.functional.normalize(output, p=2, dim=-1)
+            return [norm_embedding.squeeze(0).tolist()]
+
+
+    def extract_methods_from_java(self, source_code):
+        """
+        Extracts method declarations from Java source code and splits them into chunks.
+
+        Args:
+            source_code (str): The Java source code to process.
+
+        Returns:
+            list: A list of method chunks extracted from the source code.
+        """
+
+        tree = self.parser.parse(bytes(source_code, "utf-8"))
+        root_node = tree.root_node
+        chunks = []
+
+        def walk(node):
+            if node.type == "method_declaration":
+                method_text = self.node_text(bytes(source_code, "utf-8"), node)
+                tokens = self.tokenizer(method_text, truncation=True, add_special_tokens=False)["input_ids"]
+                token_len = len(tokens)
+
+                if token_len > self.max_tokens:
+                    stride = self.max_tokens // 2
+                    for i in range(0, token_len, stride):
+                        sub_tokens = tokens[i:i + self.max_tokens]
+                        decoded = self.tokenizer.decode(sub_tokens, skip_special_tokens=True)
+                        chunks.append(decoded)
+                        if len(sub_tokens) < self.max_tokens:
+                            break
+                else:
+                    chunks.append(method_text)
+
+            for child in node.children:
+                walk(child)
+
+        walk(root_node)
+
+        return chunks
+
+
+    def node_text(self, source_bytes, node):
+        """
+        Extracts the text corresponding to a tree-sitter node.
+
+        Args:
+            source_bytes (bytes): The source code as bytes.
+            node (tree_sitter.Node): The tree-sitter node.
+
+        Returns:
+            str: The text corresponding to the node.
+        """
+
+        return source_bytes[node.start_byte:node.end_byte].decode('utf-8')
 
 
     # File Ranking for Bug Localization

--- a/backend/utils/preprocess.py
+++ b/backend/utils/preprocess.py
@@ -123,42 +123,43 @@ class Preprocessor:
             string: preprocessed text
         """
 
-        # Remove all special chars and punctuation from the text
-        text = Preprocessor.remove_special_characters(text)
+        # # Remove all special chars and punctuation from the text
+        # text = Preprocessor.remove_special_characters(text)
 
-        # Tokenize the text
-        tokens = Preprocessor.tokenize_text(text)
+        # # Tokenize the text
+        # tokens = Preprocessor.tokenize_text(text)
 
-        try:
-            # Read stop words from the input
-            with open(stop_words_path) as f:
-                stop_words = set(f.read().splitlines())
-        except FileNotFoundError:
-            print(f"Error: The stop words at '{stop_words_path}' were not found.")
-            return
+        # try:
+        #     # Read stop words from the input
+        #     with open(stop_words_path) as f:
+        #         stop_words = set(f.read().splitlines())
+        # except FileNotFoundError:
+        #     print(f"Error: The stop words at '{stop_words_path}' were not found.")
+        #     return
 
-        # Remove stop words
-        tokens = [token for token in tokens if token not in stop_words]
+        # # Remove stop words
+        # tokens = [token for token in tokens if token not in stop_words]
         
-        # Remove cases
-        tokens = [token.lower() for token in tokens]
+        # # Remove cases
+        # tokens = [token.lower() for token in tokens]
 
-        # Lemmatize the tokens. i.e., running -> run
-        tokens = Preprocessor.lemmatize_tokens(tokens)
+        # # Lemmatize the tokens. i.e., running -> run
+        # tokens = Preprocessor.lemmatize_tokens(tokens)
         
-        # Remove short tokens
-        tokens = [token for token in tokens if len(token) > 2]
+        # # Remove short tokens
+        # tokens = [token for token in tokens if len(token) > 2]
 
-        # Join the tokens into a single string and remove cases
-        preprocessed_text = " ".join(tokens)
+        # # Join the tokens into a single string and remove cases
+        # preprocessed_text = " ".join(tokens)
 
         if verbose:
-            print(preprocessed_text)
+            print("===== ORIGINAL TEXT =====\n")
+            print(f"{text}\n")
 
         # Calculate embeddings for preprocessed text
         if is_bug_report:
-            preprocessed_text = self.bug_localizer.encode_bug_report(preprocessed_text)
+            encoded_text = self.bug_localizer.encode_bug_report(text)
         else:  
-            preprocessed_text = self.bug_localizer.encode_code(preprocessed_text)
+            encoded_text = self.bug_localizer.encode_code(text, verbose)
 
-        return preprocessed_text
+        return encoded_text

--- a/backend/utils/preprocess.py
+++ b/backend/utils/preprocess.py
@@ -105,7 +105,7 @@ class Preprocessor:
         # Call the get_pos_tag function to assign the correct POS tag to each token in tokens
         return [lemmatizer.lemmatize(token, Preprocessor.get_pos_tag(token)) for token in tokens]        
     
-    def preprocess_text(self, text, stop_words_path, verbose=True):
+    def preprocess_text(self, text, stop_words_path, verbose=True, is_bug_report=False):
         """
         Preprocesses input text by
             - Removing Numbers
@@ -156,6 +156,9 @@ class Preprocessor:
             print(preprocessed_text)
 
         # Calculate embeddings for preprocessed text
-        preprocessed_text = self.bug_localizer.encode_text(preprocessed_text,verbose=verbose)
+        if is_bug_report:
+            preprocessed_text = self.bug_localizer.encode_bug_report(preprocessed_text)
+        else:  
+            preprocessed_text = self.bug_localizer.encode_code(preprocessed_text)
 
         return preprocessed_text

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,3 +70,5 @@ urllib3==2.2.3
 wcwidth==0.2.13
 Werkzeug==3.0.6
 xmod==1.8.1
+tree-sitter==0.24.0
+tree-sitter-java==0.23.5


### PR DESCRIPTION
**Overview**
This PR replaces the old chunking approach (that chunks every 500 characters) with a method-aware chunking approach. This approach uses `tree-sitter` to generate a syntax tree of each Java source code file and only chunk each individual method within the source code file. In the case of a method that exceeds the maximum token length allowed by UniXCoder, 512 tokens, a sliding-window method is used to split the method into multiple chunks allowing for a 256 token overlap between chunks.

This PR also temporarily disables Junayed's implementation of preprocessing to allow the chunking to work. Additional print statements were added to show source code files and their chunks, **as long as verbose mode is enabled in the menu.**

**Changes Made**
- Replaced old chunking approach with method-aware chunking
- Disabled preprocessing
- Added print statements to log code file chunks
- Switched UniXCoder implementation to HuggingFace